### PR TITLE
Bump addressable from 2.4.0 to 2.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     awesome_print (1.6.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -26,9 +27,16 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.2)
+    mimemagic (0.4.3)
+      nokogiri (~> 1)
+      rake
+    mini_portile2 (2.4.0)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
+    nokogiri (1.9.1)
+      mini_portile2 (~> 2.4.0)
+    public_suffix (3.1.1)
+    rake (13.0.6)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)


### PR DESCRIPTION
### Description

In this pull request, the Gemfile.lock file is being modified to update the versions of certain gems and add new gem dependencies:

- Updated the `addressable` gem from version 2.4.0 to 2.8.0, which now requires `public_suffix` version 2.0.2 or higher but less than 5.0.
- Updated the `mimemagic` gem from version 0.3.2 to 0.4.3, which now requires `nokogiri` and `rake`.
- Added the `nokogiri` gem version 1.9.1, which also requires `mini_portile2` version 2.4.0.
- Added the `public_suffix` gem version 3.1.1.
- Added the `rake` gem version 13.0.6.