### PR TITLE
Bump json from 2.1.0 to 2.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    json (2.1.0)
+    json (2.3.1)
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)


### PR DESCRIPTION
### Description

This pull request updates the version of the `json` gem in the `Gemfile.lock` from `2.1.0` to `2.3.1`.

### Changes:
- Update the version of the `json` gem in the `Gemfile.lock` from `2.1.0` to `2.3.1`.